### PR TITLE
Thomas/pets adopt lock User Story 17

### DIFF
--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -25,6 +25,7 @@ class PetApplicationsController < ApplicationController
       application.update(status: 3)
     else
       application.update(status: 2)
+      application.update_pets
     end
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -12,4 +12,8 @@ class Application < ApplicationRecord
   def has_rejected_pets?
     pet_applications.where(approved: false).present?
   end
+
+  def update_pets
+    pets.update_all(adoptable: false)
+  end
 end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe '/admin/application/:id', type: :feature do
 
       expect(page).to have_content('Status: Accepted')
     end
+
+    it 'the adoptable attribute for each pet is changed to false' do
+      visit "/pets/#{bella.id}"
+
+      expect(page).to have_content(true)
+
+      visit "/admin/applications/#{application_1.id}"
+
+      click_button 'Approve Bella'
+      click_button 'Approve Rigby'
+
+      visit "/pets/#{bella.id}"
+
+      expect(page).to have_content(false)
+
+      visit "/pets/#{rigby.id}"
+
+      expect(page).to have_content(false)
+    end
   end
 
   describe 'When you reject one pet for an application' do


### PR DESCRIPTION
Added controller logic to update the pets on the approved application to change their adoptable status to false. 
user story 18 is currently a work in progress, but it should be just adding some logic to the admin/applications#show page. 